### PR TITLE
[issue 1] refactor: PaginationControls component

### DIFF
--- a/app/(dataEntry-sidenav)/admissionClinicalData.tsx
+++ b/app/(dataEntry-sidenav)/admissionClinicalData.tsx
@@ -1,5 +1,5 @@
 import DebugStack from '@/components/DebugStack';
-import PaginationButton from '@/components/PaginationButton';
+import PaginationControls from '@/components/PaginationControls';
 import RadioButtonGroup from '@/components/RadioButtonGroup';
 import { GlobalStyles as Styles } from '@/themes/styles';
 import { router } from 'expo-router';
@@ -258,26 +258,12 @@ export default function AdmissionClinicalDataScreen() {
                     </View>
                 </List.Section>
             </ScrollView>
-            
-            {/* Pagination controls */}
-            {/* TODO - make sure this is the correct way to navigate to different screens */}
-            <View style={Styles.paginationButtonContainer}>
-                <PaginationButton
-                    // TODO - add alerts on press ??
-                    onPress={() => {router.back()}}
-                    isNext={ false }
-                    label='Previous'
-                />
-                <PaginationButton
-                    // TODO - add alerts on press ??
-                    onPress={() => {
-                        router.push('../(dataEntry-sidenav)/medicalConditions')
-                    }}
-                    isNext={ true }
-                    label='Next'
-                />
-            </View>
-           
+            <PaginationControls
+                showPrevious={true}
+                showNext={true}
+                onPrevious={() => router.back()}
+                onNext={() => router.push('/(dataEntry-sidenav)/medicalConditions')}
+            />
         </SafeAreaView>
     );
 }

--- a/app/(dataEntry-sidenav)/caregiverContact.tsx
+++ b/app/(dataEntry-sidenav)/caregiverContact.tsx
@@ -1,12 +1,23 @@
-import { Text, View } from 'react-native';
+import DebugStack from '@/components/DebugStack';
+import PaginationControls from '@/components/PaginationControls';
+import { router } from 'expo-router';
+import { ScrollView } from 'react-native-gesture-handler';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CaregiverContactScreen() {
   
     return (
-        <>
-            <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-                <Text>Caregiver Contact Info</Text>
-            </View>
-        </>
+        <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
+            <ScrollView contentContainerStyle={{ padding: 20 }}>
+                <DebugStack/>
+            </ScrollView>
+
+        <PaginationControls
+            showPrevious={true}
+            showNext={true}
+            onPrevious={() => router.push('/(dataEntry-sidenav)/vhtReferral')}
+            onNext={() => router.push('/(dataEntry-sidenav)/review')}
+        />            
+        </SafeAreaView>
     );
 }

--- a/app/(dataEntry-sidenav)/medicalConditions.tsx
+++ b/app/(dataEntry-sidenav)/medicalConditions.tsx
@@ -1,5 +1,5 @@
 import DebugStack from '@/components/DebugStack';
-import PaginationButton from '@/components/PaginationButton';
+import PaginationControls from '@/components/PaginationControls';
 import { GlobalStyles as Styles } from '@/themes/styles';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
@@ -166,27 +166,12 @@ export default function MedicalConditionsScreen() {
                 />
 
             </ScrollView>
-
-            {/* Pagination controls */}
-            {/* TODO - make sure this is the correct way to navigate to different screens */}
-            <View style={Styles.paginationButtonContainer}>
-                <PaginationButton
-                    // TODO - add alerts on press ??
-                    onPress={() => {
-                        router.push('../(dataEntry-sidenav)/admissionClinicalData')
-                    }}
-                    isNext={ false }
-                    label='Previous'
-                />
-                <PaginationButton
-                    // TODO - add alerts on press ??
-                    onPress={() => {
-                        router.push('../(dataEntry-sidenav)/vhtReferral')
-                    }}
-                    isNext={ true }
-                    label='Next'
-                />
-            </View>
+            <PaginationControls
+                showPrevious={true}
+                showNext={true}
+                onPrevious={() => router.push('/(dataEntry-sidenav)/admissionClinicalData')}
+                onNext={() => router.push('/(dataEntry-sidenav)/vhtReferral')}
+            /> 
         </SafeAreaView>
     );
 }

--- a/app/(dataEntry-sidenav)/vhtReferral.tsx
+++ b/app/(dataEntry-sidenav)/vhtReferral.tsx
@@ -1,6 +1,6 @@
 import AutocompleteField from '@/components/AutocompleteField';
 import DebugStack from '@/components/DebugStack';
-import PaginationButton from '@/components/PaginationButton';
+import PaginationControls from '@/components/PaginationControls';
 import { GlobalStyles as Styles } from '@/themes/styles';
 import { router } from 'expo-router';
 import { useState } from 'react';
@@ -105,23 +105,12 @@ export default function VHTReferralScreen() {
                 </List.Section>
             </ScrollView>
 
-            {/* Pagination controls */}
-            <View style={Styles.paginationButtonContainer}>
-                <PaginationButton
-                    // TODO - add alerts on press ??
-                    onPress={() => {router.push('/(dataEntry-sidenav)/medicalConditions')}}
-                    isNext={ false }
-                    label='Previous'
-                />
-                <PaginationButton
-                    // TODO - add alerts on press ??
-                    onPress={() => {
-                        router.push('/(dataEntry-sidenav)/caregiverContact')
-                    }}
-                    isNext={ true }
-                    label='Next'
-                />
-            </View>
+            <PaginationControls
+                showPrevious={true}
+                showNext={true}
+                onPrevious={() => router.push('/(dataEntry-sidenav)/medicalConditions')}
+                onNext={() => router.push('/(dataEntry-sidenav)/caregiverContact')}
+            />  
         </SafeAreaView>
     );
 }

--- a/components/PaginationControls.tsx
+++ b/components/PaginationControls.tsx
@@ -1,0 +1,59 @@
+import { GlobalStyles as Styles } from '@/themes/styles';
+import React from 'react';
+import { View } from 'react-native';
+import { Button, useTheme } from 'react-native-paper';
+
+type PaginationControlsProps = {
+  onPrevious?: () => void;
+  onNext?: () => void;
+  labelPrevious?: string;
+  labelNext?: string;
+  showPrevious?: boolean;
+  showNext?: boolean;
+  disabledPrevious?: boolean;
+  disabledNext?: boolean;
+};
+
+export default function PaginationControls({
+  onPrevious,
+  onNext,
+  labelPrevious = 'Previous',
+  labelNext = 'Next',
+  showPrevious = true,
+  showNext = true,
+  disabledPrevious = false,
+  disabledNext = false,
+}: PaginationControlsProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={Styles.paginationButtonContainer}>
+      {showPrevious && (
+        <Button
+          mode="elevated"
+          buttonColor={colors.tertiary}
+          textColor={colors.onPrimary}
+          icon="arrow-left"
+          contentStyle={{ flexDirection: 'row' }}
+          onPress={onPrevious}
+          disabled={disabledPrevious}
+        >
+          {labelPrevious}
+        </Button>
+      )}
+      {showNext && (
+        <Button
+          mode="elevated"
+          buttonColor={colors.tertiary}
+          textColor={colors.onPrimary}
+          icon="arrow-right"
+          contentStyle={{ flexDirection: 'row-reverse' }}
+          onPress={onNext}
+          disabled={disabledNext}
+        >
+          {labelNext}
+        </Button>
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
Issue #1 and issue #10 
- create `PaginationControls` component to be used in screens requiring both 'next' and 'previous' buttons
- replaced dual use of `PaginationButton` with single instance if `PaginationControls` in `admissionClinicalData`, `medicalConditions`, and `vhtReferral` pages
- added to `caregiverContact` screen