### PR TITLE
refactor: PatientDataContext for local data storage

### DIFF
--- a/app/(dataEntry-sidenav)/_layout.tsx
+++ b/app/(dataEntry-sidenav)/_layout.tsx
@@ -1,3 +1,4 @@
+import { PatientDataProvider } from '@/src/contexts/PatientDataContext';
 import { MaterialIcons } from '@expo/vector-icons';
 import { createDrawerNavigator, DrawerContentScrollView, DrawerItemList } from '@react-navigation/drawer';
 import { withLayoutContext } from 'expo-router';
@@ -46,17 +47,19 @@ export default function DrawerLayout() {
     <>
     {/* <DebugStack/> */}
       <SafeAreaProvider>
-        <GestureHandlerRootView style={{ flex: 1 }}>
-          <Drawer
-            drawerContent={(props) => <CustomDrawerContent {...props}/>}>
-            <Drawer.Screen name="patientInformation" options={{title: 'Patient Information'}}/>
-            <Drawer.Screen name="admissionClinicalData" options={{title: 'Admission Clinical Data'}}/>
-            <Drawer.Screen name="medicalConditions" options={{title: 'Common Medical Conditions'}}/>
-            <Drawer.Screen name="vhtReferral" options={{title: 'VHT Referral'}}/>
-            <Drawer.Screen name="caregiverContact" options={{title: 'Caregiver Contact Information'}}/>
-            <Drawer.Screen name="review" options={{title: 'Review & Submit'}}/>
-          </Drawer>
-        </GestureHandlerRootView>
+        <PatientDataProvider>
+          <GestureHandlerRootView style={{ flex: 1 }}>
+            <Drawer
+              drawerContent={(props) => <CustomDrawerContent {...props}/>}>
+              <Drawer.Screen name="patientInformation" options={{title: 'Patient Information'}}/>
+              <Drawer.Screen name="admissionClinicalData" options={{title: 'Admission Clinical Data'}}/>
+              <Drawer.Screen name="medicalConditions" options={{title: 'Common Medical Conditions'}}/>
+              <Drawer.Screen name="vhtReferral" options={{title: 'VHT Referral'}}/>
+              <Drawer.Screen name="caregiverContact" options={{title: 'Caregiver Contact Information'}}/>
+              <Drawer.Screen name="review" options={{title: 'Review & Submit'}}/>
+            </Drawer>
+          </GestureHandlerRootView>
+        </PatientDataProvider>
       </SafeAreaProvider>
     </>
     

--- a/app/(dataEntry-sidenav)/_layout.tsx
+++ b/app/(dataEntry-sidenav)/_layout.tsx
@@ -62,6 +62,5 @@ export default function DrawerLayout() {
         </PatientDataProvider>
       </SafeAreaProvider>
     </>
-    
   );
 }

--- a/app/(dataEntry-sidenav)/admissionClinicalData.tsx
+++ b/app/(dataEntry-sidenav)/admissionClinicalData.tsx
@@ -1,6 +1,6 @@
 import PaginationControls from '@/src/components/PaginationControls';
 import RadioButtonGroup from '@/src/components/RadioButtonGroup';
-import SearchableDropdown, { DropdownItem } from '@/src/components/SearchableDropdown';
+import SearchableDropdown from '@/src/components/SearchableDropdown';
 import ValidatedTextInput, { INPUT_TYPES } from '@/src/components/ValidatedTextInput';
 import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { GlobalStyles as Styles } from '@/src/themes/styles';
@@ -15,21 +15,27 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 export default function AdmissionClinicalDataScreen() {  
     const { colors } = useTheme()
 
-    // TODO - fix setuseState and handlePress
+    // TODO - fix setuseState and handlePress ??
     const [expanded, setExpanded] = useState(false);
-    const handlePress = () => setExpanded(!expanded);
-
     const { patientData, updatePatientData, isDataLoaded } = usePatientData();
 
-    const [hivStatus, setHivStatus] = useState<string>('');
-    const [weight, setWeight] = useState<string>('');
-    const [muac, setMUAC] = useState<string>('')
-    const [temperature, setTemperature] = useState<string>('')
-    const [rrate, setRRate] = useState<string>('')
-    const [spo2, setSpO2] = useState<string>('')
-    const [heartRate, setHeartRate] = useState<string>('')
+    const handlePress = () => setExpanded(!expanded);
 
-    const [lastHospitalized, setLastHospitalized] = useState<DropdownItem | null>(null);
+    // Local state for form validation and UI
+    const {
+        hivStatus,
+        weight,
+        muac,
+        temperature,
+        rrate,
+        spo2,
+        heartRate,
+        lastHospitalized,
+        eyeMovement,
+        motorResponse,
+        verbalResponse,
+    } = patientData
+
     const hospitalizationOptions = [
     { value: 'Never', key: 'never' },
     { value: 'Less than 7 days ago', key: '<7d' },
@@ -37,13 +43,11 @@ export default function AdmissionClinicalDataScreen() {
     { value: '1 month to 1 year ago', key: '1m-1y' },
     { value: 'More than 1 year ago', key: '>1y' }];
 
-    const [eyeMovement, setEyeMovement] = useState<DropdownItem | null>(null);
     const eyeMovementOptions = [
         {value: 'Watches or follows', key: 'watches'},
         {value: 'Fails to watch or follow', key: 'fails'}
     ]
 
-    const [motorResponse, setMotorResponse] = useState<DropdownItem | null>(null);
     const motorResponseOptions = [
         {value: 'Normal behavior observed', key: 'normal'},
         {value: 'Localizes painful stimulus', key: 'localize'},
@@ -51,7 +55,6 @@ export default function AdmissionClinicalDataScreen() {
         {value: 'No resonse/inappropriate response', key: 'no-response'}
     ]
 
-    const [verbalResponse, setVerbalResponse] = useState<DropdownItem | null>(null);
     const verbalResponseOptions = [
         {value: 'Normal behavior observed', key: 'normal'},
         {value: 'Cries appropriately', key: 'cries'},
@@ -63,6 +66,15 @@ export default function AdmissionClinicalDataScreen() {
     const eyeMovementInfo =  "Have the caregiver put a toy or bright object in front of the child, and see if they are able to follow it with their eyes";
     const motorResponseInfo = "Response to pain should be assessed with firm nailbed pressure or pinch";
 
+    // Don't render until data is loaded
+    if (!isDataLoaded) {
+        return (
+            <SafeAreaView style={{flex: 1, backgroundColor: 'white', justifyContent: 'center', alignItems: 'center'}}>
+                <Text>Loading...</Text>
+            </SafeAreaView>
+        );
+    }
+    
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
             <ScrollView contentContainerStyle={{ padding: 20 }}>
@@ -79,7 +91,7 @@ export default function AdmissionClinicalDataScreen() {
                                     data={hospitalizationOptions} 
                                     label={'Last Hopitalized (required)'}
                                     placeholder='select option below' 
-                                    onSelect={setLastHospitalized}
+                                    onSelect={(value) => updatePatientData({ lastHospitalized: value })}
                                     value={lastHospitalized?.value}
                                     search={false}
                                 />
@@ -90,7 +102,7 @@ export default function AdmissionClinicalDataScreen() {
                                         { label: 'Negative', value: 'negative'},
                                         { label: 'Unknown', value: 'unknown'}]} 
                                     selected={hivStatus} 
-                                    onSelect={setHivStatus}/>
+                                    onSelect={(value) => updatePatientData({ hivStatus: value })}/>
                             </View>
                         </List.Accordion>
                     </View>
@@ -106,7 +118,7 @@ export default function AdmissionClinicalDataScreen() {
                                 <ValidatedTextInput 
                                     label={'Weight (required)'}
                                     value={weight} 
-                                    onChangeText={setWeight}
+                                    onChangeText={(value) => updatePatientData({ weight: value })}
                                     inputType={INPUT_TYPES.NUMERIC}
                                     isRequired={true} 
                                     right={<TextInput.Affix text="kg" />}                             
@@ -115,7 +127,7 @@ export default function AdmissionClinicalDataScreen() {
                                     <ValidatedTextInput 
                                         label={'MUAC (required)'}
                                         value={muac} 
-                                        onChangeText={setMUAC}
+                                        onChangeText={(value) => updatePatientData({ muac: value })}
                                         inputType={INPUT_TYPES.NUMERIC}
                                         isRequired={true} 
                                         style={[Styles.accordionTextInput, { flex: 1 }]}
@@ -133,7 +145,7 @@ export default function AdmissionClinicalDataScreen() {
                                 <ValidatedTextInput 
                                     label={'Temperature (required)'}
                                     value={temperature} 
-                                    onChangeText={setTemperature}
+                                    onChangeText={(value) => updatePatientData({ temperature: value })}
                                     inputType={INPUT_TYPES.NUMERIC}
                                     isRequired={true} 
                                     right={<TextInput.Affix text="°C" />}                             
@@ -156,7 +168,7 @@ export default function AdmissionClinicalDataScreen() {
                                 <ValidatedTextInput 
                                     label={'Breaths per minute (required)'}
                                     value={rrate} 
-                                    onChangeText={setRRate}
+                                    onChangeText={(value) => updatePatientData({ rrate: value })}
                                     inputType={INPUT_TYPES.NUMERIC}
                                     isRequired={true} 
                                     right={<TextInput.Affix text="bpm" />}                             
@@ -173,7 +185,7 @@ export default function AdmissionClinicalDataScreen() {
                                 <ValidatedTextInput 
                                     label={'SpO2 (required)'}
                                     value={spo2} 
-                                    onChangeText={setSpO2}
+                                    onChangeText={(value) => updatePatientData({ spo2: value })}
                                     inputType={INPUT_TYPES.NUMERIC}
                                     isRequired={true} 
                                     right={<TextInput.Affix text="%" />}                             
@@ -182,7 +194,7 @@ export default function AdmissionClinicalDataScreen() {
                                     label="Heart rate (required)"
                                     placeholder='Beats per minute'
                                     value={heartRate}
-                                    onChangeText={setHeartRate} 
+                                    onChangeText={(value) => updatePatientData({ heartRate: value })} 
                                     inputType={INPUT_TYPES.NUMERIC}
                                     right={<TextInput.Affix text="bpm" />}
                                 />
@@ -210,7 +222,7 @@ export default function AdmissionClinicalDataScreen() {
                                             data={eyeMovementOptions} 
                                             label={'Eye movement'}
                                             placeholder='select option below' 
-                                            onSelect={setEyeMovement}
+                                            onSelect={(value) => updatePatientData({ eyeMovement: value })}
                                             value={eyeMovement?.value}
                                             search={false}
                                         />
@@ -230,7 +242,7 @@ export default function AdmissionClinicalDataScreen() {
                                                 data={motorResponseOptions} 
                                                 label={'Best motor response'}
                                                 placeholder='select option below' 
-                                                onSelect={setMotorResponse}
+                                                onSelect={(value) => updatePatientData({ motorResponse: value })}
                                                 value={motorResponse?.value}
                                                 search={false}
                                             />
@@ -250,7 +262,7 @@ export default function AdmissionClinicalDataScreen() {
                                             data={verbalResponseOptions} 
                                             label={'Verbal response'}
                                             placeholder='select option below' 
-                                            onSelect={setVerbalResponse}
+                                            onSelect={(value) => updatePatientData({ verbalResponse: value })}
                                             value={verbalResponse?.value}
                                             search={false}
                                         />

--- a/app/(dataEntry-sidenav)/admissionClinicalData.tsx
+++ b/app/(dataEntry-sidenav)/admissionClinicalData.tsx
@@ -2,6 +2,7 @@ import PaginationControls from '@/src/components/PaginationControls';
 import RadioButtonGroup from '@/src/components/RadioButtonGroup';
 import SearchableDropdown, { DropdownItem } from '@/src/components/SearchableDropdown';
 import ValidatedTextInput, { INPUT_TYPES } from '@/src/components/ValidatedTextInput';
+import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { GlobalStyles as Styles } from '@/src/themes/styles';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
@@ -17,6 +18,8 @@ export default function AdmissionClinicalDataScreen() {
     // TODO - fix setuseState and handlePress
     const [expanded, setExpanded] = useState(false);
     const handlePress = () => setExpanded(!expanded);
+
+    const { patientData, updatePatientData, isDataLoaded } = usePatientData();
 
     const [hivStatus, setHivStatus] = useState<string>('');
     const [weight, setWeight] = useState<string>('');

--- a/app/(dataEntry-sidenav)/caregiverContact.tsx
+++ b/app/(dataEntry-sidenav)/caregiverContact.tsx
@@ -1,31 +1,42 @@
 import Checkbox from '@/src/components/Checkbox';
 import PaginationControls from '@/src/components/PaginationControls';
 import ValidatedTextInput, { INPUT_TYPES } from '@/src/components/ValidatedTextInput';
+import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { GlobalStyles as Styles } from '@/src/themes/styles';
 import { confirmPhoneErrorMessage, isValidPhoneNumber, telephoneErrorMessage } from '@/src/utils/inputValidator';
 import { router } from 'expo-router';
-import { useState } from 'react';
 import { View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Card, IconButton, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-// TODO: add evenhandlers and autosave
 // TODO: maybe replace alert with tooltip
 
 export default function CaregiverContactScreen() {
     const { colors } = useTheme();
+    const { patientData, updatePatientData, isDataLoaded } = usePatientData();
 
-    const [caregiverName, setCaregiverName] = useState<string>('');
-    const [caregiverTel, setCaregiverTel] = useState<string>('');
-    const [confirmTel, setConfirmTel] = useState<string>('')
-    const [sendReminders, setSendReminder] = useState(false);
-    const [isCaregiversPhone, setIsCaregiversPhone] = useState(false);
+    const {
+        caregiverName,
+        caregiverTel,
+        confirmTel,
+        sendReminders,
+        isCaregiversPhone
+    } = patientData
 
     const telephoneInfo = "If the patient's caregiver does not have a phone, enter the number of a relative or friend who lives nearby"
     const telephoneCheckboxInfo = "Do not select this option if the entered telephone number belongs to anyone other than the patient's caregiver (e.g. friend, neighbour, or other relative)"
 
     const isSameTelephone = caregiverTel === confirmTel
+
+    // Don't render until data is loaded
+    if (!isDataLoaded) {
+        return (
+            <SafeAreaView style={{flex: 1, backgroundColor: 'white', justifyContent: 'center', alignItems: 'center'}}>
+                <Text>Loading...</Text>
+            </SafeAreaView>
+        );
+    }    
 
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
@@ -49,7 +60,7 @@ export default function CaregiverContactScreen() {
                     label="Name of Head of Family (required)"
                     placeholder="Enter name of the patient's primary caregiver"
                     value={caregiverName}
-                    onChangeText={setCaregiverName}
+                    onChangeText={(value) => updatePatientData({caregiverName: value})}
                     inputType={INPUT_TYPES.TEXT}
                     isRequired={true}
                 />
@@ -58,7 +69,7 @@ export default function CaregiverContactScreen() {
                         label="Telephone"
                         placeholder="Enter phone number"  
                         value={caregiverTel}
-                        onChangeText={setCaregiverTel}
+                        onChangeText={(value) => updatePatientData({ caregiverTel: value })}
                         inputType={INPUT_TYPES.PHONE}
                         customValidator={() => isValidPhoneNumber(caregiverTel)}
                         customErrorMessage={telephoneErrorMessage}
@@ -79,7 +90,7 @@ export default function CaregiverContactScreen() {
                     placeholder="Re-enter phone number"  
                     inputType='phone' 
                     value={confirmTel}
-                    onChangeText={setConfirmTel}
+                    onChangeText={(value) => updatePatientData({ confirmTel: value })}
                     customValidator={() => isSameTelephone && isValidPhoneNumber(caregiverTel)}
                     customErrorMessage={confirmPhoneErrorMessage}
                     isRequired={caregiverTel ? true : false} //caregiverTel.trim() !== ''
@@ -92,7 +103,7 @@ export default function CaregiverContactScreen() {
                         <Checkbox 
                             label={'Phone number belongs to caregiver'} 
                             checked={isCaregiversPhone} 
-                            onChange={() => {setIsCaregiversPhone((prev) => !prev)}}/>
+                            onChange={() => updatePatientData({isCaregiversPhone: !isCaregiversPhone})}/>
                         <IconButton
                         icon="help-circle-outline"
                         size={20}
@@ -102,7 +113,7 @@ export default function CaregiverContactScreen() {
                     
                     <Checkbox label={'Receive reminders by text message'} 
                                 checked={sendReminders} 
-                                onChange={() => {setSendReminder((prev) => !prev)}}/>
+                                onChange={() => updatePatientData({sendReminders: !sendReminders})}/>
                 </View>
 
             </ScrollView>

--- a/app/(dataEntry-sidenav)/medicalConditions.tsx
+++ b/app/(dataEntry-sidenav)/medicalConditions.tsx
@@ -1,25 +1,32 @@
 import PaginationControls from '@/src/components/PaginationControls';
-import SearchableDropdown, { DropdownItem } from '@/src/components/SearchableDropdown';
+import SearchableDropdown from '@/src/components/SearchableDropdown';
+import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { GlobalStyles as Styles } from '@/src/themes/styles';
 import { router } from 'expo-router';
-import React, { useState } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Card, IconButton, Text, TextInput, useTheme } from 'react-native-paper';
-// import { Dropdown } from 'react-native-paper-dropdown';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function MedicalConditionsScreen() {
     const { colors } = useTheme();
-    
-    const [ anaemia, setAnaemia ] = useState<DropdownItem | null>(null);
-    const [ pneumonia, setPneumonia ] = useState<DropdownItem | null>(null);
-    const [ chronicIllness, setChronicIllness ] = useState<DropdownItem | null>(null);
-    const [ acuteDiarrhea, setAcuteDiarrhea ] = useState<DropdownItem | null>(null);
-    const [ malaria, setMalaria ] = useState<DropdownItem | null>(null);
-    const [ sepsis, setSepsis ] = useState<DropdownItem | null>(null);
-    const [ meningitis, setMeningitis ] = useState<DropdownItem | null>(null);
+    const { patientData, updatePatientData, isDataLoaded } = usePatientData();
+
+    // TODO - measure malnutrition status and if sickYoungInfant (must be <28 days old)
+
+    const {
+        anaemia,
+        pneumonia,
+        chronicIllness,
+        acuteDiarrhea,
+        malaria,
+        sepsis,
+        meningitis,
+        malnutritionStatus,
+        sickYoungInfant
+    } = patientData
 
     const diagnosisOptions = [
         { value: 'Yes - positive diagnosis', key: 'yes'},
@@ -32,7 +39,16 @@ export default function MedicalConditionsScreen() {
         { value: 'Yes', key: 'yes'},
         { value: 'No', key: 'no'},
     ]
-      
+    
+    // Don't render until data is loaded
+    if (!isDataLoaded) {
+        return (
+            <SafeAreaView style={{flex: 1, backgroundColor: 'white', justifyContent: 'center', alignItems: 'center'}}>
+                <Text>Loading...</Text>
+            </SafeAreaView>
+        );
+    }
+
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
             {/* <DebugStack/> */}
@@ -66,7 +82,7 @@ export default function MedicalConditionsScreen() {
                     />
                 </View>
                 
-               <View style = {{flexDirection: 'row', alignItems: 'center', marginBottom: 8}}>
+               {/* <View style = {{flexDirection: 'row', alignItems: 'center', marginBottom: 8}}>
                     <TextInput 
                         label="Sick young infant" 
                         mode="flat" 
@@ -83,22 +99,22 @@ export default function MedicalConditionsScreen() {
                         alert("Applies to infants less than 28 days old. \nAutomatically determined based on patient's age");
                         }}
                     />
-                </View>
+                </View> */}
                 
                 <SearchableDropdown 
                     data={diagnosisOptions} 
                     label={'Pneumonia'}
                     placeholder='select option below' 
-                    onSelect={setPneumonia}
-                    value={pneumonia?.value}
+                    onSelect={(value) => updatePatientData({ pneumonia: value })}
+                    value={pneumonia?.key}
                     search={false}
                 />
                 <SearchableDropdown 
                     data={diagnosisOptions} 
                     label={'Severe anaemia'}
                     placeholder='select option below' 
-                    onSelect={setAnaemia}
-                    value={anaemia?.value}
+                    onSelect={(value) => updatePatientData({ anaemia: value })}
+                    value={anaemia?.key}
                     search={false}
                 />
 
@@ -108,8 +124,8 @@ export default function MedicalConditionsScreen() {
                             data={diagnosisOptions} 
                             label={'Chronic illnesses'}
                             placeholder='select option below' 
-                            onSelect={setChronicIllness}
-                            value={chronicIllness?.value}
+                            onSelect={(value) => updatePatientData({ chronicIllness: value })}
+                            value={chronicIllness?.key}
                             search={false}
                         />
                     </View>
@@ -127,33 +143,33 @@ export default function MedicalConditionsScreen() {
                 <SearchableDropdown 
                     label = {'Acute diarrhea'}
                     data = {simplifiedOptions}
-                    value = {acuteDiarrhea?.value}
+                    value = {acuteDiarrhea?.key}
                     placeholder='select option below'
-                    onSelect={setAcuteDiarrhea}
+                    onSelect={(value) => updatePatientData({ acuteDiarrhea: value })}
                     search={false}
                 />
                 <SearchableDropdown 
                     label = {'Malaria'}
                     data = {diagnosisOptions}
-                    value = {malaria?.value}
+                    value = {malaria?.key}
                     placeholder='select option below' 
-                    onSelect={setMalaria}
+                    onSelect={(value) => updatePatientData({ malaria: value })}
                     search={false}
                 />
                 <SearchableDropdown 
                     label = {'Sepsis'}
                     data = {diagnosisOptions}
-                    value = {sepsis?.value}
+                    value = {sepsis?.key}
                     placeholder='select option below' 
-                    onSelect = {setSepsis}
+                    onSelect = {(value) => updatePatientData({ sepsis: value })}
                     search={false}
                 />
                 <SearchableDropdown 
                     label = {'Meningitis/Encephalitis'}
                     data = {diagnosisOptions}
-                    value = {meningitis?.value}
+                    value = {meningitis?.key}
                     placeholder='select option below' 
-                    onSelect = {setMeningitis}
+                    onSelect = {(value) => updatePatientData({ meningitis: value })}
                     search={false}
                 />
 

--- a/app/(dataEntry-sidenav)/patientInformation.tsx
+++ b/app/(dataEntry-sidenav)/patientInformation.tsx
@@ -5,7 +5,6 @@ import SearchableDropdown from '@/src/components/SearchableDropdown';
 import ValidatedTextInput, { INPUT_TYPES } from '@/src/components/ValidatedTextInput';
 import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { GlobalStyles as Styles } from '@/src/themes/styles';
-import { AgeCalculator } from '@/src/utils/ageCalculator';
 import { ageErrorMessage, isValidAge, isValidYearInput, yearErrorMessage } from '@/src/utils/inputValidator';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { router } from 'expo-router';
@@ -19,22 +18,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 // TODO - add age validation for DOB and birth year/month - ensure estimated age is <= 5.5!
 
 export default function PatientInformationScreen() {
-    // const [sex, setSex] = useState<string>('');
-    // const [isUnderSixMonths, setIsUnderSixMonths] = useState(false);
-    // const [isDOBUnknown, setIsDOBUnknown] = useState(false);
-    // const [isYearMonthUnknown, setIsYearMonthUnknown] = useState(false);
-    // const [previewPatientId, setPreviewPatientId] = useState<string>('');
-    
-    // const [surname, setSurname] = useState<string>('');
-    // const [firstName, setFirstName] = useState<string>('');
-    // const [otherName, setOtherName] = useState<string>('');
-    
-    // const [dob, setDOB] = useState<Date | null>(null);
-    // const [showDatePicker, setShowDatePicker] = useState(false);
-    // const [birthYear, setBirthYear] = useState<string>('');
-    // const [birthMonth, setBirthMonth] = useState<DropdownItem | null>(null);
-    // const [approxAge, setApproxAge] = useState<string>('');
-
     const { patientData, updatePatientData, getPreviewPatientId, startAdmission, isDataLoaded } = usePatientData();
     const [previewPatientId, setPreviewPatientId] = useState<string>('');
     const [showDatePicker, setShowDatePicker] = useState(false);
@@ -54,11 +37,11 @@ export default function PatientInformationScreen() {
         approxAge
     } = patientData;
 
-    console.log('dob', dob)
-    console.log('year', birthYear)
-    console.log('month', birthMonth)
-    console.log('approxAge', approxAge)
-    console.log('calculated age', AgeCalculator.calculateAgeInYears(dob, birthYear, birthMonth, approxAge))
+    // console.log('dob', dob)
+    // console.log('year', birthYear)
+    // console.log('month', birthMonth)
+    // console.log('approxAge', approxAge)
+    // console.log('calculated age', AgeCalculator.calculateAgeInYears(dob, birthYear, birthMonth, approxAge))
     
     const handleDateChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
         if (event.type === "set" && selectedDate) {
@@ -69,10 +52,6 @@ export default function PatientInformationScreen() {
                 birthMonth: null,
                 approxAge: ''
             })
-            // setDOB(selectedDate);
-            // setBirthYear('');
-            // setBirthMonth(null);
-            // setApproxAge('');
         }
     
         if (Platform.OS === "android") {
@@ -160,8 +139,7 @@ export default function PatientInformationScreen() {
                 <Text style={Styles.sectionHeader}>Age <Text style={Styles.required}>*</Text></Text>
                 <Checkbox label={'Patient is less than 6 months old'} 
                           checked={isUnderSixMonths} 
-                          onChange={() => updatePatientData({isUnderSixMonths: !isUnderSixMonths})}/>. 
-                        {/* {() => {setIsUnderSixMonths((prev) => !prev)}} */}
+                          onChange={() => updatePatientData({isUnderSixMonths: !isUnderSixMonths})}/> 
                 <Checkbox label={'Exact date of birth (DOB) unknown'} 
                         checked={isDOBUnknown} 
                         onChange={() => {
@@ -177,21 +155,6 @@ export default function PatientInformationScreen() {
                                     approxAge: ''
                                 })
                             })
-                            // setIsDOBUnknown(prev => {
-                            //     const newValue = !prev;
-                            //     setDOB(null) // reset DOB value when checkbox clicked
-
-                            //     if (!newValue) { // DOB is known
-                            //         setIsYearMonthUnknown(false); // reset when DOB is known
-                                    
-                            //         // clear less detailed age fields
-                            //         setBirthYear('')
-                            //         setBirthMonth(null)
-                            //         setApproxAge('')
-                            //     }
-                            //     return newValue;
-
-                            // });
                         }}
                 />  
                 {
@@ -236,20 +199,6 @@ export default function PatientInformationScreen() {
                                         approxAge: ''
                                     })
                                 });
-                                // setIsYearMonthUnknown((prev) => {
-                                //     const newVal = !prev; // change checkbox val
-                                    
-                                //     // reset year/month when checkbox clicked
-                                //     setBirthYear('')
-                                //     setBirthMonth(null)
-
-                                //     // if birth year and birth month are known clear other age values
-                                //     if (!newVal) {
-                                //         setDOB(null)
-                                //         setApproxAge('')
-                                //     }
-                                //     return newVal;
-                                // })
                             }}
                         />  
                         {
@@ -296,7 +245,6 @@ export default function PatientInformationScreen() {
             {/* Pagination controls */}
             <View style={Styles.nextButtonContainer}>
                 <PaginationButton
-                    // TODO - add alerts on press ??
                     onPress={() => 
                         {router.push('../(dataEntry-sidenav)/admissionClinicalData')}}
                     isNext={ true }

--- a/app/(dataEntry-sidenav)/patientInformation.tsx
+++ b/app/(dataEntry-sidenav)/patientInformation.tsx
@@ -58,8 +58,7 @@ export default function PatientInformationScreen() {
     console.log('year', birthYear)
     console.log('month', birthMonth)
     console.log('approxAge', approxAge)
-    console.log('estimated age', AgeCalculator.calculateEstimatedAge(dob, birthYear, birthMonth, approxAge))
-
+    console.log('calculated age', AgeCalculator.calculateAgeInYears(dob, birthYear, birthMonth, approxAge))
     
     const handleDateChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
         if (event.type === "set" && selectedDate) {

--- a/app/(dataEntry-sidenav)/patientInformation.tsx
+++ b/app/(dataEntry-sidenav)/patientInformation.tsx
@@ -1,12 +1,12 @@
 import Checkbox from '@/src/components/Checkbox';
 import PaginationButton from '@/src/components/PaginationButton';
 import RadioButtonGroup from '@/src/components/RadioButtonGroup';
-import SearchableDropdown, { DropdownItem } from '@/src/components/SearchableDropdown';
+import SearchableDropdown from '@/src/components/SearchableDropdown';
 import ValidatedTextInput, { INPUT_TYPES } from '@/src/components/ValidatedTextInput';
+import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { GlobalStyles as Styles } from '@/src/themes/styles';
 import { AgeCalculator } from '@/src/utils/ageCalculator';
 import { ageErrorMessage, isValidAge, isValidYearInput, yearErrorMessage } from '@/src/utils/inputValidator';
-import { PatientIdGenerator } from '@/src/utils/patientIdGenerator';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
@@ -16,25 +16,43 @@ import { TextInput } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 
-// TODO - add age validation for DOB and birth year/month!
-// TODO - find good date picker for DOB
+// TODO - add age validation for DOB and birth year/month - ensure estimated age is <= 5.5!
 
 export default function PatientInformationScreen() {
-    const [sex, setSex] = useState<string>('');
-    const [isUnderSixMonths, setIsUnderSixMonths] = useState(false);
-    const [isDOBUnknown, setIsDOBUnknown] = useState(false);
-    const [isYearMonthUnknown, setIsYearMonthUnknown] = useState(false);
+    // const [sex, setSex] = useState<string>('');
+    // const [isUnderSixMonths, setIsUnderSixMonths] = useState(false);
+    // const [isDOBUnknown, setIsDOBUnknown] = useState(false);
+    // const [isYearMonthUnknown, setIsYearMonthUnknown] = useState(false);
+    // const [previewPatientId, setPreviewPatientId] = useState<string>('');
+    
+    // const [surname, setSurname] = useState<string>('');
+    // const [firstName, setFirstName] = useState<string>('');
+    // const [otherName, setOtherName] = useState<string>('');
+    
+    // const [dob, setDOB] = useState<Date | null>(null);
+    // const [showDatePicker, setShowDatePicker] = useState(false);
+    // const [birthYear, setBirthYear] = useState<string>('');
+    // const [birthMonth, setBirthMonth] = useState<DropdownItem | null>(null);
+    // const [approxAge, setApproxAge] = useState<string>('');
+
+    const { patientData, updatePatientData, getPreviewPatientId, startAdmission, isDataLoaded } = usePatientData();
     const [previewPatientId, setPreviewPatientId] = useState<string>('');
-    
-    const [surname, setSurname] = useState<string>('');
-    const [firstName, setFirstName] = useState<string>('');
-    const [otherName, setOtherName] = useState<string>('');
-    
-    const [dob, setDOB] = useState<Date | null>(null);
     const [showDatePicker, setShowDatePicker] = useState(false);
-    const [birthYear, setBirthYear] = useState<string>('');
-    const [birthMonth, setBirthMonth] = useState<DropdownItem | null>(null);
-    const [approxAge, setApproxAge] = useState<string>('');
+
+    // Local state for form validation and UI
+    const {
+        sex,
+        isUnderSixMonths,
+        isDOBUnknown,
+        isYearMonthUnknown,
+        surname,
+        firstName,
+        otherName,
+        dob,
+        birthYear,
+        birthMonth,
+        approxAge
+    } = patientData;
 
     console.log('dob', dob)
     console.log('year', birthYear)
@@ -46,10 +64,16 @@ export default function PatientInformationScreen() {
     const handleDateChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
         if (event.type === "set" && selectedDate) {
             // make sure only one of these age params are set to non-null at a time (except year and month must be set together)
-            setDOB(selectedDate);
-            setBirthYear('');
-            setBirthMonth(null);
-            setApproxAge('');
+            updatePatientData({
+                dob: selectedDate,
+                birthYear: '',
+                birthMonth: null,
+                approxAge: ''
+            })
+            // setDOB(selectedDate);
+            // setBirthYear('');
+            // setBirthMonth(null);
+            // setApproxAge('');
         }
     
         if (Platform.OS === "android") {
@@ -74,11 +98,23 @@ export default function PatientInformationScreen() {
 
     useEffect(() => {
         const fetchId = async () => {
-        const id = await PatientIdGenerator.getPreviewPatientId();
+        const id = await getPreviewPatientId();
         setPreviewPatientId(id);
         };
         fetchId();
+
+        // Start admission tracking when user first enters patient information screen
+        startAdmission();
     }, []);
+
+    // Don't render until data is loaded
+    if (!isDataLoaded) {
+        return (
+            <SafeAreaView style={{flex: 1, backgroundColor: 'white', justifyContent: 'center', alignItems: 'center'}}>
+                <Text>Loading...</Text>
+            </SafeAreaView>
+        );
+    }
 
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
@@ -92,21 +128,21 @@ export default function PatientInformationScreen() {
                  <ValidatedTextInput 
                     label="Surname (required)" 
                     value={surname}
-                    onChangeText={setSurname}
+                    onChangeText={(value) => updatePatientData({ surname: value })}
                     inputType={INPUT_TYPES.TEXT}
                     isRequired={true}
                 />
                 <ValidatedTextInput 
                     label="First Name (required)" 
                     value={firstName}
-                    onChangeText={setFirstName}
+                    onChangeText={(value) => updatePatientData({ firstName: value })}
                     inputType={INPUT_TYPES.TEXT}
                     isRequired={true}
                 />
                  <ValidatedTextInput 
                     label="Other Name (optional)" 
                     value={otherName}
-                    onChangeText={setOtherName}
+                    onChangeText={(value) => updatePatientData({ otherName: value })}
                     inputType={INPUT_TYPES.TEXT}
                     isRequired={false}
                     showErrorOnTyping={true}
@@ -119,31 +155,44 @@ export default function PatientInformationScreen() {
                         { label: 'Male', value: 'male'},
                         { label: 'Female', value: 'female'}]} 
                     selected={sex} 
-                    onSelect={setSex}/>
+                    onSelect={(value) => updatePatientData({ sex: value })}/>
 
                 {/* Age Section */}
                 <Text style={Styles.sectionHeader}>Age <Text style={Styles.required}>*</Text></Text>
                 <Checkbox label={'Patient is less than 6 months old'} 
                           checked={isUnderSixMonths} 
-                          onChange={() => {setIsUnderSixMonths((prev) => !prev)}}/>
+                          onChange={() => updatePatientData({isUnderSixMonths: !isUnderSixMonths})}/>. 
+                        {/* {() => {setIsUnderSixMonths((prev) => !prev)}} */}
                 <Checkbox label={'Exact date of birth (DOB) unknown'} 
                         checked={isDOBUnknown} 
                         onChange={() => {
-                            setIsDOBUnknown(prev => {
-                                const newValue = !prev;
-                                setDOB(null) // reset DOB value when checkbox clicked
+                            const newValue = !isDOBUnknown;
+                            updatePatientData({
+                                isDOBUnknown: newValue,
+                                dob: null,
+                                ...(newValue ? {} : {
+                                    // reset and clear all othe fields when dob unknown checked
+                                    isYearMonthUnknown: false,
+                                    birthYear: '',
+                                    birthMonth: null,
+                                    approxAge: ''
+                                })
+                            })
+                            // setIsDOBUnknown(prev => {
+                            //     const newValue = !prev;
+                            //     setDOB(null) // reset DOB value when checkbox clicked
 
-                                if (!newValue) { // DOB is known
-                                    setIsYearMonthUnknown(false); // reset when DOB is known
+                            //     if (!newValue) { // DOB is known
+                            //         setIsYearMonthUnknown(false); // reset when DOB is known
                                     
-                                    // clear less detailed age fields
-                                    setBirthYear('')
-                                    setBirthMonth(null)
-                                    setApproxAge('')
-                                }
-                                return newValue;
+                            //         // clear less detailed age fields
+                            //         setBirthYear('')
+                            //         setBirthMonth(null)
+                            //         setApproxAge('')
+                            //     }
+                            //     return newValue;
 
-                            });
+                            // });
                         }}
                 />  
                 {
@@ -178,20 +227,30 @@ export default function PatientInformationScreen() {
                             label={'Birth year and month unknown'} 
                             checked={isYearMonthUnknown} 
                             onChange={() => {
-                                setIsYearMonthUnknown((prev) => {
-                                    const newVal = !prev; // change checkbox val
+                                const newVal = !isYearMonthUnknown;
+                                updatePatientData({
+                                    isYearMonthUnknown: newVal,
+                                    birthYear: '',
+                                    birthMonth: null,
+                                    ...(newVal ? {} : {
+                                        dob: null,
+                                        approxAge: ''
+                                    })
+                                });
+                                // setIsYearMonthUnknown((prev) => {
+                                //     const newVal = !prev; // change checkbox val
                                     
-                                    // reset year/month when checkbox clicked
-                                    setBirthYear('')
-                                    setBirthMonth(null)
+                                //     // reset year/month when checkbox clicked
+                                //     setBirthYear('')
+                                //     setBirthMonth(null)
 
-                                    // if birth year and birth month are known clear other age values
-                                    if (!newVal) {
-                                        setDOB(null)
-                                        setApproxAge('')
-                                    }
-                                    return newVal;
-                                })
+                                //     // if birth year and birth month are known clear other age values
+                                //     if (!newVal) {
+                                //         setDOB(null)
+                                //         setApproxAge('')
+                                //     }
+                                //     return newVal;
+                                // })
                             }}
                         />  
                         {
@@ -202,7 +261,7 @@ export default function PatientInformationScreen() {
                                 <ValidatedTextInput 
                                     label="Birth Year" 
                                     value={birthYear}
-                                    onChangeText={setBirthYear}
+                                    onChangeText={(value) => updatePatientData({ birthYear: value })}
                                     inputType={INPUT_TYPES.NUMERIC}
                                     style={{marginTop: 10}}
                                     customValidator={() => isValidYearInput(birthYear)}
@@ -213,7 +272,7 @@ export default function PatientInformationScreen() {
                                     data={months} 
                                     label={'Birth Month'}
                                     placeholder="Search for or select patient's birth month" 
-                                    onSelect={setBirthMonth}
+                                    onSelect={(value) => updatePatientData({ birthMonth: value })}
                                     value={birthMonth?.value}
                                     search={true}
                                     style={{marginTop: 10}}
@@ -223,19 +282,16 @@ export default function PatientInformationScreen() {
                             <ValidatedTextInput 
                                 label="Approximate Age (in years)" 
                                 value={approxAge}
-                                onChangeText={setApproxAge}
+                                onChangeText={(value) => updatePatientData({ approxAge: value })}
                                 inputType={INPUT_TYPES.NUMERIC}
                                 customValidator={() => isValidAge(approxAge)}
                                 customErrorMessage={ageErrorMessage}
                                 isRequired={true}
                                 right={<TextInput.Affix text="years old" />}
                             />
-                        }
-                        
+                        }       
                     </>
                 }
-                        
-                
             </ScrollView>
             
             {/* Pagination controls */}

--- a/app/(dataEntry-sidenav)/review.tsx
+++ b/app/(dataEntry-sidenav)/review.tsx
@@ -1,17 +1,55 @@
-import { PatientIdGenerator } from '@/src/utils/patientIdGenerator';
+import { usePatientData } from '@/src/contexts/PatientDataContext';
 import { router } from 'expo-router';
+import { useState } from 'react';
+import { Alert } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Button, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ReviewScreen() {
     const { colors } = useTheme()
+    const { patientData, savePatientData, clearPatientData } = usePatientData();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // const handleSubmit = async () => {
+    //     const finalPID = await PatientIdGenerator.generatePatientId()
+    //     router.push('/') // TODO - reroute to prediction screen, not home
+
+    // }
 
     const handleSubmit = async () => {
-        const finalPID = await PatientIdGenerator.generatePatientId()
-        router.push('/') // TODO - reroute to prediction screen, not home
+        try {
+            setIsSubmitting(true);
+            
+            // Validate required fields TODO -- add more required fields
+            const requiredFields = ['surname', 'firstName', 'sex'];
+            const missingFields = requiredFields.filter(field => !patientData[field as keyof typeof patientData]);
+            
+            if (missingFields.length > 0) {
+                Alert.alert('Missing Information', `Please fill in: ${missingFields.join(', ')}`);
+                return;
+            }
 
-    }
+            // Save patient data permanently and get the final patient ID
+            const finalPatientId = await savePatientData();
+            
+            Alert.alert(
+                'Success', 
+                `Patient data has been saved successfully!\nPatient ID: ${finalPatientId}`,
+                [
+                    {
+                        text: 'OK',
+                        onPress: () => router.push('/') // todo - change to risk display screen
+                    }
+                ]
+            );
+        } catch (error) {
+            console.error('Error submitting patient data:', error);
+            Alert.alert('Error', 'Failed to save patient data. Please try again.');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
   
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>

--- a/app/(dataEntry-sidenav)/review.tsx
+++ b/app/(dataEntry-sidenav)/review.tsx
@@ -84,11 +84,11 @@ export default function ReviewScreen() {
         children: React.ReactNode; 
         onEdit: () => void 
     }) => (
-        <Card style={[Styles.cardWrapper, { marginBottom: 16 }]}>
+        <Card style={[Styles.cardWrapper, { marginBottom: 16 }, ]}>
             <Card.Content>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
                     <Text variant="headlineSmall" style={{ fontWeight: 'bold' }}>{title}</Text>
-                    <Button mode="outlined" onPress={onEdit} compact>
+                    <Button mode="elevated" onPress={onEdit} compact buttonColor='white'>
                         Edit
                     </Button>
                 </View>
@@ -105,18 +105,18 @@ export default function ReviewScreen() {
         </View>
     );
   
+    // TODO - use accordions instead; if opened and viewed icon changed to 'check' and is green
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
             <ScrollView contentContainerStyle={{ padding: 20 }}>
                 <ReviewSection 
                     title="Patient Information" 
-                    onEdit={() => handleEdit('patientInformation')}
-                >
+                    onEdit={() => handleEdit('patientInformation')}>
                     <InfoRow label="Full Name" value={`${patientData.firstName} ${patientData.otherName} ${patientData.surname}`.trim()} />
                     <InfoRow label="Sex" value={patientData.sex} />
-                    <InfoRow label="Age Information" value={formatAge()} />
+                    <InfoRow label="DOB/Age" value={formatAge()} />
                     <InfoRow label="Under 6 months" value={patientData.isUnderSixMonths ? 'Yes' : 'No'} />
-                    <InfoRow label="Admission Started" value={formatDateTime(patientData.admissionStartedAt)} />
+                    {/* <InfoRow label="Admission Started" value={formatDateTime(patientData.admissionStartedAt)} /> */}
                 </ReviewSection>
 
                 <Button

--- a/app/(dataEntry-sidenav)/review.tsx
+++ b/app/(dataEntry-sidenav)/review.tsx
@@ -1,10 +1,12 @@
 import { usePatientData } from '@/src/contexts/PatientDataContext';
+import { GlobalStyles as Styles } from '@/src/themes/styles';
 import { router } from 'expo-router';
 import { useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { Button, useTheme } from 'react-native-paper';
+import { Button, Card, Divider, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
 
 export default function ReviewScreen() {
     const { colors } = useTheme()
@@ -50,18 +52,83 @@ export default function ReviewScreen() {
             setIsSubmitting(false);
         }
     };
+
+    const handleEdit = (screen: string) => {
+        router.push(`/(dataEntry-sidenav)/${screen}` as any);
+    };
+
+    const formatDate = (date: Date | null): string => {
+        if (!date) return 'Not provided';
+        return date.toISOString().split('T')[0];
+    };
+
+    const formatDateTime = (isoString: string | null): string => {
+        if (!isoString) return 'Not recorded';
+        const date = new Date(isoString);
+        return date.toLocaleString();
+    };
+
+    const formatAge = () => {
+        if (patientData.dob) {
+            return formatDate(patientData.dob);
+        } else if (patientData.birthYear && patientData.birthMonth) {
+            return `${patientData.birthMonth.value} ${patientData.birthYear}`;
+        } else if (patientData.approxAge) {
+            return `${patientData.approxAge} years old`;
+        }
+        return 'Not provided';
+    };
+
+    const ReviewSection = ({ title, children, onEdit }: { 
+        title: string; 
+        children: React.ReactNode; 
+        onEdit: () => void 
+    }) => (
+        <Card style={[Styles.cardWrapper, { marginBottom: 16 }]}>
+            <Card.Content>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+                    <Text variant="headlineSmall" style={{ fontWeight: 'bold' }}>{title}</Text>
+                    <Button mode="outlined" onPress={onEdit} compact>
+                        Edit
+                    </Button>
+                </View>
+                <Divider style={{ marginBottom: 12 }} />
+                {children}
+            </Card.Content>
+        </Card>
+    );
+
+    const InfoRow = ({ label, value }: { label: string; value: string }) => (
+        <View style={{ flexDirection: 'row', marginBottom: 8 }}>
+            <Text style={{ fontWeight: 'bold', flex: 1 }}>{label}:</Text>
+            <Text style={{ flex: 2 }}>{value || 'Not provided'}</Text>
+        </View>
+    );
   
     return (
         <SafeAreaView style={{flex: 1, backgroundColor: 'white'}}>
             <ScrollView contentContainerStyle={{ padding: 20 }}>
+                <ReviewSection 
+                    title="Patient Information" 
+                    onEdit={() => handleEdit('patientInformation')}
+                >
+                    <InfoRow label="Full Name" value={`${patientData.firstName} ${patientData.otherName} ${patientData.surname}`.trim()} />
+                    <InfoRow label="Sex" value={patientData.sex} />
+                    <InfoRow label="Age Information" value={formatAge()} />
+                    <InfoRow label="Under 6 months" value={patientData.isUnderSixMonths ? 'Yes' : 'No'} />
+                    <InfoRow label="Admission Started" value={formatDateTime(patientData.admissionStartedAt)} />
+                </ReviewSection>
+
                 <Button
                     style={{ alignSelf: 'center' }}
                     mode="elevated"
                     buttonColor={colors.primary}
                     textColor={colors.onPrimary}
                     onPress={handleSubmit}
+                    loading={isSubmitting}
+                    disabled={isSubmitting}
                 >
-                    Submit
+                    {isSubmitting ? 'Saving Patient Data...' : 'Submit Patient Data'}
                 </Button>
             </ScrollView>
         </SafeAreaView>

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,3 +6,4 @@ export const ACTIVE_DISTRICT = 'buikwe';
 export const ACTIVE_SITE = 'SITE';
 export const DEVICE_ID_KEY = 'A'
 export const CURRENT_USER = 'Muna'
+export const MAX_PATIENT_AGE = 5.5;

--- a/src/contexts/PatientDataContext.tsx
+++ b/src/contexts/PatientDataContext.tsx
@@ -35,7 +35,6 @@ export interface PatientData {
   motorResponse: DropdownItem | null;
   verbalResponse: DropdownItem | null;
 
-
   // Medical Conditions
   anaemia: DropdownItem | null;
   pneumonia: DropdownItem | null;
@@ -46,7 +45,6 @@ export interface PatientData {
   meningitis: DropdownItem | null;
   
   // Add other screen data as needed
-  // admissionClinicalData: { ... };
   // vhtReferral: { ... };
   // caregiverContact: { ... };
 }

--- a/src/contexts/PatientDataContext.tsx
+++ b/src/contexts/PatientDataContext.tsx
@@ -46,9 +46,14 @@ export interface PatientData {
   malnutritionStatus: string;
   sickYoungInfant: boolean | null;
   
-  // Add other screen data as needed
-  // vhtReferral: { ... };
-  // caregiverContact: { ... };
+  // TODO add vhtReferral data : { ... };
+  
+  // caregiverContact
+  caregiverName: string;
+  caregiverTel: string;
+  confirmTel: string;
+  sendReminders: boolean;
+  isCaregiversPhone: boolean;
 }
 
 const initialPatientData: PatientData = {
@@ -89,6 +94,13 @@ const initialPatientData: PatientData = {
   meningitis: null,
   malnutritionStatus: '',
   sickYoungInfant: null,
+
+  // caregiver info
+  caregiverName: '',
+  caregiverTel: '',
+  confirmTel: '',
+  isCaregiversPhone: false,
+  sendReminders: false,
 };
 
 interface PatientDataContextType {

--- a/src/contexts/PatientDataContext.tsx
+++ b/src/contexts/PatientDataContext.tsx
@@ -1,0 +1,223 @@
+// src/contexts/PatientDataContext.tsx
+import { PatientIdGenerator } from '@/src/utils/patientIdGenerator';
+import * as SecureStore from 'expo-secure-store';
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+
+// Define your data structure based on all screens
+export interface PatientData {
+  // Metadata
+  admissionStartedAt: string | null;
+  
+  // Patient Information
+  surname: string;
+  firstName: string;
+  otherName: string;
+  sex: string;
+  isUnderSixMonths: boolean;
+  isDOBUnknown: boolean;
+  isYearMonthUnknown: boolean;
+  dob: Date | null;
+  birthYear: string;
+  birthMonth: { value: string; key: string } | null;
+  approxAge: string;
+  
+  // Medical Conditions
+  anaemia: { value: string; key: string } | null;
+  pneumonia: { value: string; key: string } | null;
+  chronicIllness: { value: string; key: string } | null;
+  acuteDiarrhea: { value: string; key: string } | null;
+  malaria: { value: string; key: string } | null;
+  sepsis: { value: string; key: string } | null;
+  meningitis: { value: string; key: string } | null;
+  
+  // Add other screen data as needed
+  // admissionClinicalData: { ... };
+  // vhtReferral: { ... };
+  // caregiverContact: { ... };
+}
+
+const initialPatientData: PatientData = {
+  admissionStartedAt: null,
+  surname: '',
+  firstName: '',
+  otherName: '',
+  sex: '',
+  isUnderSixMonths: false,
+  isDOBUnknown: false,
+  isYearMonthUnknown: false,
+  dob: null,
+  birthYear: '',
+  birthMonth: null,
+  approxAge: '',
+  anaemia: null,
+  pneumonia: null,
+  chronicIllness: null,
+  acuteDiarrhea: null,
+  malaria: null,
+  sepsis: null,
+  meningitis: null,
+};
+
+interface PatientDataContextType {
+  patientData: PatientData;
+  updatePatientData: (updates: Partial<PatientData>) => void;
+  clearPatientData: () => void;
+  savePatientData: () => Promise<string>;
+  getPreviewPatientId: () => Promise<string>;
+  startAdmission: () => void;
+  isDataLoaded: boolean;
+}
+
+const PatientDataContext = createContext<PatientDataContextType | undefined>(undefined);
+
+const TEMP_STORAGE_KEY = 'temp_patient_data';
+const SUBMITTED_DATA_KEY = 'submitted_patient_data';
+
+export function PatientDataProvider({ children }: { children: ReactNode }) {
+  const [patientData, setPatientData] = useState<PatientData>(initialPatientData);
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
+
+  // Load temporary data on app start
+  useEffect(() => {
+    loadTempData();
+  }, []);
+
+  const loadTempData = async () => {
+    try {
+      const tempData = await SecureStore.getItemAsync(TEMP_STORAGE_KEY);
+      if (tempData) {
+        const parsedData = JSON.parse(tempData);
+        // Convert date strings back to Date objects
+        if (parsedData.dob) {
+          parsedData.dob = new Date(parsedData.dob);
+        }
+        setPatientData(parsedData);
+      }
+    } catch (error) {
+      console.error('Error loading temp data:', error);
+    } finally {
+      setIsDataLoaded(true);
+    }
+  };
+
+  const updatePatientData = async (updates: Partial<PatientData>) => {
+    const newData = { ...patientData, ...updates };
+    setPatientData(newData);
+    
+    // Auto-save to temporary storage
+    try {
+      await SecureStore.setItemAsync(TEMP_STORAGE_KEY, JSON.stringify(newData));
+      console.log('🔄 Auto-saved patient data:', JSON.stringify(updates, null, 2));
+    } catch (error) {
+      console.error('Error auto-saving data:', error);
+    }
+  };
+
+  const clearPatientData = async () => {
+    setPatientData(initialPatientData);
+    try {
+      await SecureStore.deleteItemAsync(TEMP_STORAGE_KEY);
+    } catch (error) {
+      console.error('Error clearing temp data:', error);
+    }
+  };
+
+  const savePatientData = async (): Promise<string> => {
+    try {
+      // Save to permanent storage
+      const existingData = await SecureStore.getItemAsync(SUBMITTED_DATA_KEY);
+      const submittedData = existingData ? JSON.parse(existingData) : [];
+      
+      // Generate the final patient ID using your existing generator
+      const finalPatientId = await PatientIdGenerator.generatePatientId();
+      
+      const patientRecord = {
+        ...patientData,
+        patientId: finalPatientId,
+        submittedAt: new Date().toISOString(),
+      };
+      
+      submittedData.push(patientRecord);
+      await SecureStore.setItemAsync(SUBMITTED_DATA_KEY, JSON.stringify(submittedData));
+      
+      console.log('✅ Patient data saved successfully!');
+      console.log('📄 Patient Record:', JSON.stringify(patientRecord, null, 2));
+      console.log('📊 Total submitted patients:', submittedData.length);
+
+      // Clear temporary data
+      await clearPatientData();
+      
+      return finalPatientId;
+    } catch (error) {
+      console.error('Error saving patient data:', error);
+      throw error;
+    }
+  };
+
+  const getPreviewPatientId = async (): Promise<string> => {
+    return await PatientIdGenerator.getPreviewPatientId();
+  };
+
+  const startAdmission = () => {
+    if (!patientData.admissionStartedAt) {
+      updatePatientData({ admissionStartedAt: new Date().toISOString() });
+    }
+  };
+
+   // Debug functions for testing
+//   const getAllSubmittedPatients = async (): Promise<any[]> => {
+//     try {
+//       const existingData = await SecureStore.getItemAsync(SUBMITTED_DATA_KEY);
+//       return existingData ? JSON.parse(existingData) : [];
+//     } catch (error) {
+//       console.error('Error getting submitted patients:', error);
+//       return [];
+//     }
+//   };
+
+//   const clearAllSubmittedPatients = async (): Promise<void> => {
+//     try {
+//       await SecureStore.deleteItemAsync(SUBMITTED_DATA_KEY);
+//       console.log('All submitted patients cleared');
+//     } catch (error) {
+//       console.error('Error clearing submitted patients:', error);
+//     }
+//   };
+
+//   const getTempPatientData = async (): Promise<any> => {
+//     try {
+//       const tempData = await SecureStore.getItemAsync(TEMP_STORAGE_KEY);
+//       return tempData ? JSON.parse(tempData) : null;
+//     } catch (error) {
+//       console.error('Error getting temp data:', error);
+//       return null;
+//     }
+//   };
+
+  return (
+    <PatientDataContext.Provider
+      value={{
+        patientData,
+        updatePatientData,
+        clearPatientData,
+        savePatientData,
+        getPreviewPatientId,
+        startAdmission,
+        isDataLoaded,
+        // getAllSubmittedPatients,
+        // clearAllSubmittedPatients,
+        // getTempPatientData,
+      }}
+    >
+      {children}
+    </PatientDataContext.Provider>
+  );
+}
+
+export const usePatientData = () => {
+  const context = useContext(PatientDataContext);
+  if (context === undefined) {
+    throw new Error('usePatientData must be used within a PatientDataProvider');
+  }
+  return context;
+};

--- a/src/contexts/PatientDataContext.tsx
+++ b/src/contexts/PatientDataContext.tsx
@@ -43,6 +43,8 @@ export interface PatientData {
   malaria: DropdownItem | null;
   sepsis: DropdownItem | null;
   meningitis: DropdownItem | null;
+  malnutritionStatus: string;
+  sickYoungInfant: boolean | null;
   
   // Add other screen data as needed
   // vhtReferral: { ... };
@@ -85,6 +87,8 @@ const initialPatientData: PatientData = {
   malaria: null,
   sepsis: null,
   meningitis: null,
+  malnutritionStatus: '',
+  sickYoungInfant: null,
 };
 
 interface PatientDataContextType {

--- a/src/contexts/PatientDataContext.tsx
+++ b/src/contexts/PatientDataContext.tsx
@@ -46,7 +46,11 @@ export interface PatientData {
   malnutritionStatus: string;
   sickYoungInfant: boolean | null;
   
-  // TODO add vhtReferral data : { ... };
+  // vhtReferral info
+  village: DropdownItem | null;
+  subvillage: string;
+  vhtName: DropdownItem | null;
+  vhtTelephone: DropdownItem | null;
   
   // caregiverContact
   caregiverName: string;
@@ -93,7 +97,13 @@ const initialPatientData: PatientData = {
   sepsis: null,
   meningitis: null,
   malnutritionStatus: '',
-  sickYoungInfant: null,
+  sickYoungInfant: null, // TODO - change to false?
+
+  // vht referral information
+  village: null,
+  subvillage: '',
+  vhtName: null,
+  vhtTelephone: null,
 
   // caregiver info
   caregiverName: '',

--- a/src/contexts/PatientDataContext.tsx
+++ b/src/contexts/PatientDataContext.tsx
@@ -2,6 +2,7 @@
 import { PatientIdGenerator } from '@/src/utils/patientIdGenerator';
 import * as SecureStore from 'expo-secure-store';
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { DropdownItem } from '../components/SearchableDropdown';
 
 // Define your data structure based on all screens
 export interface PatientData {
@@ -18,17 +19,31 @@ export interface PatientData {
   isYearMonthUnknown: boolean;
   dob: Date | null;
   birthYear: string;
-  birthMonth: { value: string; key: string } | null;
+  birthMonth: DropdownItem | null;
   approxAge: string;
   
+  // Admission Clinical Data
+  hivStatus: string;
+  weight: string;
+  muac: string;
+  temperature: string;
+  rrate: string;
+  spo2: string;
+  heartRate: string;
+  lastHospitalized: DropdownItem | null;
+  eyeMovement: DropdownItem | null;
+  motorResponse: DropdownItem | null;
+  verbalResponse: DropdownItem | null;
+
+
   // Medical Conditions
-  anaemia: { value: string; key: string } | null;
-  pneumonia: { value: string; key: string } | null;
-  chronicIllness: { value: string; key: string } | null;
-  acuteDiarrhea: { value: string; key: string } | null;
-  malaria: { value: string; key: string } | null;
-  sepsis: { value: string; key: string } | null;
-  meningitis: { value: string; key: string } | null;
+  anaemia: DropdownItem | null;
+  pneumonia: DropdownItem | null;
+  chronicIllness: DropdownItem | null;
+  acuteDiarrhea: DropdownItem | null;
+  malaria: DropdownItem | null;
+  sepsis: DropdownItem | null;
+  meningitis: DropdownItem | null;
   
   // Add other screen data as needed
   // admissionClinicalData: { ... };
@@ -37,6 +52,7 @@ export interface PatientData {
 }
 
 const initialPatientData: PatientData = {
+  // patient information
   admissionStartedAt: null,
   surname: '',
   firstName: '',
@@ -49,6 +65,21 @@ const initialPatientData: PatientData = {
   birthYear: '',
   birthMonth: null,
   approxAge: '',
+
+  // admission clinical data
+  hivStatus: '',
+  weight: '',
+  muac: '',
+  temperature: '',
+  rrate: '',
+  spo2: '',
+  heartRate: '',
+  lastHospitalized: null,
+  eyeMovement: null,
+  motorResponse: null,
+  verbalResponse: null,
+
+  // medical conditions
   anaemia: null,
   pneumonia: null,
   chronicIllness: null,

--- a/src/utils/__tests__/ageCalculator.test.ts
+++ b/src/utils/__tests__/ageCalculator.test.ts
@@ -1,150 +1,165 @@
-import { DropdownItem } from "@/src/components/SearchableDropdown";
 import { AgeCalculator } from "../ageCalculator";
 
 
-describe('monthToIndex', () => {
-    const jan: DropdownItem = {key: "Jan", value: "January"}
-    const dec: DropdownItem = {key: "Dec", value: "December"}
-    const emptyKey = {key: "", value: ""}
+describe('AgeCalculator', () => {
+  const FIXED_DATE = new Date('2025-08-26T00:00:00Z'); // control today's date
 
-    it('returns 0 for January', () => {
-        expect(AgeCalculator.__test.monthToIndex(jan)).toBe(0);
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(FIXED_DATE);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe('monthToIndex', () => {
+    it('should map month keys to correct indices', () => {
+      expect(AgeCalculator.__test.monthToIndex({ key: 'Jan', value: 'January' })).toBe(0);
+      expect(AgeCalculator.__test.monthToIndex({ key: 'Dec', value: 'December' })).toBe(11);
+      expect(AgeCalculator.__test.monthToIndex({ key: 'Invalid', value: 'January' })).toBe(-1);
+    });
+  });
+
+  describe('createDob', () => {    
+    const expectedDate = new Date(2020, 1, 15)
+    it('should create correct Date from year and month', () => {
+      const dob = AgeCalculator.__test.createDob('2020', { key: 'Feb', value: 'February' });
+      expect(dob.toISOString()).toBe(expectedDate.toISOString());
+    });
+  });
+
+  describe('calculateAgeInYears', () => {
+    const invalidInputError = "No valid age information provided. Please supply DOB, birth year/month, or approximate age."
+    const validDob = new Date('2022-08-26')
+
+    it('should calculate from dob only', () => {
+      const age = AgeCalculator.calculateAgeInYears(validDob, '', null, '');
+      expect(age).toBeCloseTo(3, 1);
     });
 
-    it('returns 11 for December', () => {
-        expect(AgeCalculator.__test.monthToIndex(dec)).toBe(11);
+    it('should calculate from birthYear and birthMonth', () => {
+      const age = AgeCalculator.calculateAgeInYears(
+        null,
+        '2020',
+        { key: 'Aug', value: 'August' },
+        ''
+      );
+      expect(age).toBeCloseTo(5, 1);
     });
 
-    it('returns -1 if key not in month list', () => {
-        expect(AgeCalculator.__test.monthToIndex(emptyKey)).toBe(-1);
+    it('should calculate from approxAge string', () => {
+      const age = AgeCalculator.calculateAgeInYears(null, '', null, '3.7');
+      expect(age).toBe(3.7);
     });
+
+    it('should throw an error when only birth year provided', () => {
+        try {
+            AgeCalculator.calculateAgeInYears(null, '2025', null, '');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe(invalidInputError);
+        }
+    });
+
+    it('should throw an error when dob and birth year provided', () => {
+        try {
+            AgeCalculator.calculateAgeInYears(validDob, '2025', null, '');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe(invalidInputError);
+        }
+    });
+
+    it('should throw an error when birth year and approx age provided', () => {
+        try {
+            AgeCalculator.calculateAgeInYears(null, '2025', null, '3.5');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe(invalidInputError);
+        }
+    });
+
+    it('should throw an error when all inputs are empty or invalid', () => {
+        try {
+            AgeCalculator.calculateAgeInYears(null, '', null, '');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe(invalidInputError);
+        }
+    });
+
+    it('should throw an error when invalid approx age entered', () => {
+        try {
+            AgeCalculator.calculateAgeInYears(null, '', null, '3.7a');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe("Approximate age is not a valid number.");
+        }
+    });
+
+    it('should throw an error when future DOB from datepicker', () => {
+        const dob = new Date('2025-08-27T00:00:00Z')
+        try {
+            AgeCalculator.calculateAgeInYears(dob, '', null, '');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe("DOB cannot be in the future");
+        }
+    });
+
+    it('should throw an error when future DOB from birth year and month', () => {
+        const year = '2025'
+        const month = {key: 'Sep', value: 'September'}
+        try {
+            AgeCalculator.calculateAgeInYears(null, year, month, '');
+            // If no error is thrown, fail the test explicitly
+            fail('Expected error to be thrown but none was.');
+        } catch (e) {
+            const err = e as Error;
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBeDefined();
+            expect(err.message).toBe("DOB (calculated from birth year/month) cannot be in the future");
+        }
+    });
+  });
+
+  describe('getAgeInMonths', () => {
+    it('should calculate age in months from dob', () => {
+      const dob = new Date('2023-08-26');
+      const months = AgeCalculator.getAgeInMonths(dob, null);
+      expect(months).toBeCloseTo(24, 1); // ~24 months
+    });
+
+    it('should calculate age in months from years', () => {
+      const months = AgeCalculator.getAgeInMonths(null, 3);
+      expect(months).toBeCloseTo(0.25, 1); // 3 / 12 = 0.25
+    });
+  });
 
 });
 
-describe('getAgeFromDOB', () => {
-    // Mock the current date for consistent testing
-    const mockCurrentDate = new Date('2024-06-15T10:00:00Z'); // June 15, 2024
-    
-    beforeAll(() => {
-        jest.useFakeTimers();
-        jest.setSystemTime(mockCurrentDate);
-    });
-
-    afterAll(() => {
-        jest.useRealTimers();
-    });
-
-    describe('exact age calculations', () => {
-        it('should calculate exact whole years', () => {
-            const dob = new Date('2020-06-15'); // Exactly 4 years ago
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBe(4.0);
-        });
-
-        it('should calculate age with half year (6 months)', () => {
-            const dob = new Date('2020-12-15'); // 3.5 years ago
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBe(3.5);
-        });
-
-        it('should calculate age with quarter year (3 months)', () => {
-            const dob = new Date('2021-03-15'); // 3.25 years ago
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBe(3.25);
-        });
-    });
-
-    describe('complex date calculations', () => {
-        it('should handle birthday that has not occurred this year', () => {
-            const dob = new Date('2020-08-15'); // Birthday in August, current date June
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(3.84, 2); // Approximately 3 years 10 months
-        });
-
-        it('should handle birthday that already occurred this year', () => {
-            const dob = new Date('2020-03-15'); // Birthday in March, current date June
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(4.25, 2); // Approximately 4 years 3 months
-        });
-
-        it('should handle month boundary with negative days', () => {
-            const dob = new Date('2020-05-30'); // May 30
-            // Current: June 15, so 1 year, 0 months, 16 days
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(4.04, 1); // Should be close to 4 years
-        });
-    });
-
-    describe('edge cases', () => {
-        it('should handle leap year births', () => {
-            const dob = new Date('2020-02-29'); // Leap year birthday
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(4.29, 1); // About 4 years 3.5 months
-        });
-
-        it('should handle very young children (under 1 year)', () => {
-            const dob = new Date('2024-01-15'); // About 5 months ago
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(0.42, 2); // About 5 months = 0.42 years
-        });
-
-        it('should handle newborns (under 1 month)', () => {
-            const dob = new Date('2024-06-01'); // 14 days ago
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(0.04, 2); // About 14 days
-        });
-
-        it('should handle same day birth (0 age)', () => {
-            const dob = new Date('2024-06-15'); // Today
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBe(0);
-        });
-    });
-
-    describe.only('month boundary edge cases', () => {
-        it('should handle end of month births', () => {
-            const dob = new Date('2020-01-31'); // January 31
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeCloseTo(4.37, 1); // Should handle month with 31 days
-        });
-
-        it.only('should handle February to March transition', () => {
-            // Set current date to March 15 for this test
-            jest.setSystemTime(new Date('2024-03-15T10:00:00Z'));
-            
-            const dob = new Date('2020-02-15'); // February 15
-            const age = AgeCalculator.__test.getAgeInYearsFromDOB2(dob); // TODO fiugre out which function to use
-            expect(age).toBe(4.08); // 4 years + 1 month
-            
-            // Reset to original mock date
-            jest.setSystemTime(mockCurrentDate);
-        });
-    });
-
-    describe('precision and rounding', () => {
-        it('should round to 2 decimal places', () => {
-            const dob = new Date('2020-04-01'); // Creates a non-round number
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            
-            // Check that result has at most 2 decimal places
-            const decimalPlaces = (age.toString().split('.')[1] || '').length;
-            expect(decimalPlaces).toBeLessThanOrEqual(2);
-        });
-    });
-
-    describe('future dates (edge case)', () => {
-        it('should handle future birth dates', () => {
-            const dob = new Date('2025-01-01'); // Future date
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBeLessThan(0); // Should be negative
-        });
-    });
-
-    describe('historical dates', () => {
-        it('should handle very old dates', () => {
-            const dob = new Date('1950-06-15'); // 74 years ago
-            const age = AgeCalculator.__test.getAgeFromDOB(dob);
-            expect(age).toBe(74.0);
-        });
-    });
-});

--- a/src/utils/inputValidator.ts
+++ b/src/utils/inputValidator.ts
@@ -30,7 +30,6 @@ export function formatText(input: string): string {
  *  Must contain only allow letters, spaces, hyphen, exclamation marks, or apostrophe, and be 2 or more characters
  */ 
 export function isValidTextFormat(input: string): boolean {
-    console.log('validating input...', input)
     if (!input) return true;
     if (!input.trim()) return false;
 
@@ -154,9 +153,7 @@ export function isValidPhoneNumber(input: string): boolean {
     }
 
     // Numeric validation
-    export function isValidNumericFormat(input: string, minValue: number | null = null, maxValue: number | null = null): boolean {
-        console.log('validating numeric input...', input);
-        
+    export function isValidNumericFormat(input: string, minValue: number | null = null, maxValue: number | null = null): boolean {        
         if (!input || !input.trim()) {
             return false;
         }


### PR DESCRIPTION
- add `PatientDataContext` to store entered data as single patient record
- wrap drawer layout with PatientDataProvider
- refactor all data entry screens to use PatientDataContext `usePatientData` instead of state management with useStates